### PR TITLE
Bug fix. Spacing from the net class is not applied.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ replicate_layout.log
 !main.kicad_pro
 *.kicad_sch-bak
 *.kicad_pcb-bak
+~*.lck

--- a/JLCPCB Rules Test.kicad_dru
+++ b/JLCPCB Rules Test.kicad_dru
@@ -1,25 +1,39 @@
 (version 1)
 #Kicad 7
 
-# ----------------------------------- Minimum trace width and spacing (PICK ONE) --------------------
+# ----------------------------------- Minimum trace width (PICK ONE) --------------------
 
 # 2oz copper
-#(rule "Minimum Trace Width and Spacing"
+#(rule "Minimum Trace Width"
 #	(constraint track_width (min 0.2mm))
-#	(constraint clearance (min 0.2mm))
 #	(condition "A.Type == 'track'"))
 
 # 2-layer, 1oz copper
-#(rule "Minimum Trace Width and Spacing (outer layer)"
+#(rule "Minimum Trace Width (outer layer)"
 #	(constraint track_width (min 0.127mm))
-#	(constraint clearance (min 0.127mm))
 #	(condition "A.Type == 'track'"))
 
 # 4-layer , 1oz and 0.5oz copper
-(rule "Minimum Trace Width and Spacing"
+(rule "Minimum Trace Width"
 	(constraint track_width (min 0.09mm))
-	(constraint clearance (min 0.09mm))
 	(condition "A.Type == 'track'"))
+
+# ----------------------------------- Minimum trace spacing (PICK ONE) --------------------
+
+# 2oz copper
+#(rule "Minimum Trace Spacing"
+#	(constraint clearance (min 0.2mm))
+#	(condition "A.Type == 'track' && B.Type != 'zone'"))
+
+# 2-layer, 1oz copper
+#(rule "Minimum Trace Spacing (outer layer)"
+#	(constraint clearance (min 0.127mm))
+#	(condition "A.Type == 'track' && B.Type != 'zone'"))
+
+# 4-layer , 1oz and 0.5oz copper
+(rule "Minimum Trace Spacing"
+	(constraint clearance (min 0.09mm))
+	(condition "A.Type == 'track' && B.Type != 'zone'"))
 
 # ------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I noticed a flaw in DRC.
Problem: polygon fill ignores track spacing parameters (net class, polygon parameters).
Solution: Separate the spacing check into a separate block and add a condition.

I find this change very useful. To match lines, it is necessary to be able to locally change the spacing of a specific track.

Was:
![image](https://github.com/tinfever/KiCAD-Custom-DRC-Rules-for-JLCPCB-with-Unit-Tests/assets/50487552/e9a61b2c-d994-4bca-b6c1-8d58ab2bb906)

Became:
![image](https://github.com/tinfever/KiCAD-Custom-DRC-Rules-for-JLCPCB-with-Unit-Tests/assets/50487552/780e7d3e-7d34-4836-b298-6ad138d88b26)

P.S. [Project from screenshot](https://github.com/MuratovAS/opr)